### PR TITLE
Improving time_length for 29 Feb (when dealing with date time)

### DIFF
--- a/R/intervals.r
+++ b/R/intervals.r
@@ -632,15 +632,12 @@ setMethod("time_length", signature("Interval"), function(x, unit = "second") {
     periods <- as.period(x, unit = unit)
     int_part <- slot(periods, unit)
 
-    neg <- x@.Data < 0
-    pos <- !neg
-    prev_aniv <- next_aniv <- int_start(x)
-
-    prev_aniv[pos] <- int_start(x)[pos] %m++% (int_part [pos] * period(1, units = unit))
-    next_aniv[pos] <- int_start(x)[pos] %m++% ((int_part[pos] + 1L) * period(1, units = unit))
-
-    prev_aniv[neg] <- int_start(x)[neg] %m+% (int_part[neg] * period(1, units = unit))
-    next_aniv[neg] <- int_start(x)[neg] %m+% ((int_part[neg] - 1L) * period(1, units = unit))
+    prev_aniv <- .month_plus(
+      int_start(x), (int_part * period(1, units = unit)), 
+      roll_to_first = TRUE, preserve_hms = FALSE)
+    next_aniv <- .month_plus(
+      int_start(x), ((int_part + ifelse(x@.Data < 0, -1, 1)) * period(1, units = unit)), 
+      roll_to_first = TRUE, preserve_hms = FALSE)
       
     sofar <- as.duration(int_end(x) - prev_aniv)
     total <- as.duration(next_aniv - prev_aniv)

--- a/inst/tests/test-rollback.R
+++ b/inst/tests/test-rollback.R
@@ -1,0 +1,13 @@
+context("rollback")
+
+test_that("rollback returns correct results",{
+  expect_equal(rollback(ymd_hms("2010-03-03 12:44:22")),
+               ymd_hms("2010-02-28 12:44:22"))
+  expect_equal(rollback(ymd_hms("2010-03-03 12:44:22"), preserve_hms = FALSE),
+               ymd_hms("2010-02-28 00:00:00"))
+  expect_equal(rollback(ymd_hms("2010-03-03 12:44:22"), roll_to_first = TRUE),
+               ymd_hms("2010-03-01 12:44:22"))
+  expect_equal(rollback(ymd_hms("2010-03-03 12:44:22"), roll_to_first = TRUE, preserve_hms = FALSE),
+               ymd_hms("2010-03-01 00:00:00"))
+})
+

--- a/inst/tests/test-timespans.R
+++ b/inst/tests/test-timespans.R
@@ -48,6 +48,8 @@ test_that("time_length works with birth date 29 Feb ", {
               equals(8.0027))
   expect_that(time_length(interval(ymd('1992-02-29'), ymd('2000-02-29')), "years"), 
               equals(8))
+  expect_that(time_length(interval(ymd_hms('1992-02-29 12:00:00'), ymd_hms('1999-03-01 05:00:00')), "years"), 
+              is_more_than(7))
 })
 
 test_that("time_length works with negative interals", {
@@ -97,7 +99,7 @@ test_that("time_length handles vectors",{
 
   expect_equal(round(time_length(ints, "month"), 5),
                c(2.4402, 625.99538, 60.57729, -194.06691, -145.2291, 520.81679, 
-                 -72.35552, -425.27918, -795.42705, 44.57974))
+                 -72.35552, -425.27918, -795.43557, 44.57974))
 })
 
 test_that("time_length handles 0 length intervals", {


### PR DESCRIPTION
With previous version, we had:

```r
> naiss <- ymd_hms("1992-02-29 12:00:00")
> evt <- ymd_hms("2014-03-01 01:00:00")
> time_length(interval(naiss, evt), "years")
[1] 21.99874
```

We should consider that the anniversary occurs between 28 Feb at 23:59:59 and 1st March at 00:00:00. Therefore, `%m++%` should rollback at 00:00:00. In that case:

```r
> time_length(interval(naiss, evt), "years")
[1] 22.00011
```
