### PR TITLE
Allow to parse dates from long numbers

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,8 @@
+
+BUG FIXES
+
+* allow to parse long numbers such as 20140911000000 as date+time (@jiho, #302)
+
 Version 1.3.3
 -------------------------------------------------------------------------
 

--- a/R/parse.r
+++ b/R/parse.r
@@ -695,7 +695,7 @@ fast_strptime <- function(x, format, tz = "UTC"){
   if (is.numeric(x)) {
     out <- rep.int(as.character(NA), length(x))
     nnas <- !is.na(x)
-    x <- as.character(x[nnas])
+    x <- format(x[nnas], scientific = FALSE, trim = TRUE)
     x <- paste(ifelse(nchar(x) %% 2 == 1, "0", ""), x, sep = "")
     out[nnas] <- x
     out

--- a/inst/tests/test-parsers.R
+++ b/inst/tests/test-parsers.R
@@ -156,6 +156,16 @@ test_that("ymd functions correctly parse dates with no separators and no quotes"
               equals(as.POSIXct("2010-01-02 23:59:59", tz = "UTC")))
 })
 
+test_that("all numbers are correctly converted into character for parsing", {
+  # Conversion to character of numbers with 000000 at the end with as.character()
+  # may outputs scientific notation depending on the value of the 'scipen' option.
+  # .num_to_date() uses format() to avoid that. Check that it does indeed work
+  expect_that(ymd_hms(20100102000000),
+              equals(as.POSIXct("2010-01-02 00:00:00", tz = "UTC")))
+  expect_that(.num_to_date(20100102000000),
+              equals("20100102000000"))
+})
+
 test_that("ymd functions parse absurd formats as NA's", {
   ## should not through errors, just as as.POSIX and strptime
   pna <- as.POSIXct(as.POSIXlt(NA, tz = "UTC"))


### PR DESCRIPTION
With as.character(), long numbers get converted to scientific
notation which the parse of course fails to recognise. Using
format(..., scientific = FALSE) prevents that.