### PR TITLE
[Fix #336] coercion from interval to period

### DIFF
--- a/R/coercion.r
+++ b/R/coercion.r
@@ -441,9 +441,10 @@ setMethod("as.period", signature(x = "Interval"), function(x, unit = NULL, ...) 
   to.per$month[nmons] <- 12 + to.per$month[nmons]
   to.per$year[nmons] <- to.per$year[nmons] - 1
   
-  np <- new("Period", to.per$second, year = to.per$year, month = to.per$month, 
+  np <- new("Period", to.per$second, year = to.per$year, month = to.per$month,
             day = to.per$day, hour = to.per$hour, minute = to.per$minute)
-  if (abs(sign(np@month) - sign(np@day))) np@day <- 0
+  if (is.na(np@month) | is.na(np@day)) return(np)
+  if (abs(sign(np@month) - sign(np@day)) == 2) np@day <- 0
   np
 }
 

--- a/R/coercion.r
+++ b/R/coercion.r
@@ -441,8 +441,10 @@ setMethod("as.period", signature(x = "Interval"), function(x, unit = NULL, ...) 
   to.per$month[nmons] <- 12 + to.per$month[nmons]
   to.per$year[nmons] <- to.per$year[nmons] - 1
   
-  new("Period", to.per$second, year = to.per$year, month = to.per$month, 
-    day = to.per$day, hour = to.per$hour, minute = to.per$minute)
+  np <- new("Period", to.per$second, year = to.per$year, month = to.per$month, 
+            day = to.per$day, hour = to.per$hour, minute = to.per$minute)
+  if (abs(sign(np@month) - sign(np@day))) np@day <- 0
+  np
 }
 
 setMethod("as.period", signature(x = "Duration"), function(x, unit = NULL, ...) {


### PR DESCRIPTION
If the sign of the `@month` and `@day` slots of the new period are opposite to each other, set `@day` to zero.
https://github.com/hadley/lubridate/issues/336

It is my understanding that negative periods are legal but a period created from an interval should not have a negative month slot and positive days or vice versa.

First attempted in pull request https://github.com/hadley/lubridate/pull/346 but there was an error in the test and it didn't handle NAs.  Sorry if it fails the `testthat` tests; I need to learn how to understand and run those myself locally.  Hope you take this attempted bugfix in good faith if it doesn't work; I won't try again if it fails.