### PR TITLE
Specify GPL version from src/tparse.c

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: lubridate
 Maintainer: Vitalie Spinu <spinuvit@gmail.com>
-License: GPL
+License: GPL-2
 Title: Make Dealing with Dates a Little Easier
 LazyData: true
 Type: Package


### PR DESCRIPTION
src/tparse.c specifies GPL-2 but the DESCRIPTION file just says GPL.  This patch fixes it.