### PR TITLE
Corrected minor typo in title of round.r

### DIFF
--- a/R/round.r
+++ b/R/round.r
@@ -1,4 +1,4 @@
-#' Round, flour and ceiling methods for date-time objects.
+#' Round, floor and ceiling methods for date-time objects.
 #'
 #' Users can specify whether to round to the nearest second, minute, hour, day,
 #' week, month, quarter, or year.


### PR DESCRIPTION
Title of documentation was "Round, flour and ceiling methods for date-time objects." Because no baking is involved, I assumed "flour" should be "floor".