### PR TITLE
Add "bimonth" and "halfyear" options to round_date and friends

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@ Version 1.5.6.9000 (development)
 ### NEW FEATURES
 
 * [#412](https://github.com/hadley/lubridate/issues/412) New function `make_date` to produce Date objects. A counterpart of `make_datetime`.
+* [#268](https://github.com/hadley/lubridate/issues/268) `round_date`, `ceiling_date`, and `floor_date` now accept "quarter", "bimonth", and "halfyear" as `unit` options.
 
 
 ### CHANGES

--- a/R/round.r
+++ b/R/round.r
@@ -1,7 +1,7 @@
 #' Round, floor and ceiling methods for date-time objects.
 #'
 #' Users can specify whether to round to the nearest second, minute, hour, day,
-#' week, month, quarter, or year.
+#' week, month, bimonth, quarter, halfyear, or year.
 #'
 #' \code{round_date} takes a date-time object and rounds it to the nearest
 #' integer value of the specified time unit. For rounding date-ties which is
@@ -22,7 +22,7 @@
 #' @rdname round_date
 #' @param x a vector of date-time objects
 #' @param unit a character string specifying the time unit to be rounded to. Should be one of
-#'   "second", "minute", "hour", "day", "week", "month", "quarter", or "year."
+#'   "second", "minute", "hour", "day", "week", "month", "bimonth", "quarter", "halfyear", or "year."
 #' @return x with the appropriate units floored
 #' @keywords manip chron
 #' @seealso \link[base]{round}
@@ -40,7 +40,11 @@
 #' # "2009-08-02 CDT"
 #' round_date(x, "month")
 #' # "2009-08-01 CDT"
+#' round_date(x, "bimonth")
+#' # "2009-09-01 CDT"
 #' round_date(x, "quarter")
+#' # "2009-07-01 CDT"
+#' round_date(x, "halfyear")
 #' # "2009-07-01 CDT"
 #' round_date(x, "year")
 #' # "2010-01-01 CST"
@@ -58,7 +62,11 @@
 #' # "2009-08-02 CDT"
 #' floor_date(x, "month")
 #' # "2009-08-01 CDT"
+#' floor_date(x, "bimonth")
+#' # "2009-07-01 CDT"
 #' floor_date(x, "quarter")
+#' # "2009-07-01 CDT"
+#' floor_date(x, "halfyear")
 #' # "2009-07-01 CDT"
 #' floor_date(x, "year")
 #' # "2009-01-01 CST"
@@ -76,12 +84,16 @@
 #' # "2009-08-09 CDT"
 #' ceiling_date(x, "month")
 #' # "2009-09-01 CDT"
+#' ceiling_date(x, "bimonth")
+#' # "2009-09-01 CDT"
 #' ceiling_date(x, "quarter")
 #' # "2009-10-01 CDT"
+#' ceiling_date(x, "halfyear")
+#' # "2010-01-01 CDT"
 #' ceiling_date(x, "year")
 #' # "2010-01-01 CST"
 #' @export
-round_date <- function(x, unit = c("second", "minute", "hour", "day", "week", "month", "year", "quarter")) {
+round_date <- function(x, unit = c("second", "minute", "hour", "day", "week", "month", "bimonth", "quarter", "halfyear", "year")) {
 
   if(!length(x)) return(x)
 
@@ -106,8 +118,8 @@ round_date <- function(x, unit = c("second", "minute", "hour", "day", "week", "m
 
 #' @rdname round_date
 #' @export
-floor_date <- function(x, unit = c("second", "minute", "hour", "day", "week", "month", "year", "quarter")) {
-	if(!length(x)) return(x)
+floor_date <- function(x, unit = c("second", "minute", "hour", "day", "week", "month", "bimonth", "quarter", "halfyear", "year")) {
+  if(!length(x)) return(x)
   unit <- match.arg(unit)
 
   if(unit %in% c("second", "minute", "hour", "day")){
@@ -115,10 +127,12 @@ floor_date <- function(x, unit = c("second", "minute", "hour", "day", "week", "m
   } else {
 
     new <- switch(unit,
-                  week    = update(x, wdays = 1, hours = 0, minutes = 0, seconds = 0),
-                  month   = update(x, mdays = 1, hours = 0, minutes = 0, seconds = 0),
-                  quarter = update(x, months = ((month(x)-1)%/%3)*3+1, mdays = 1, hours = 0, minutes = 0, seconds = 0),
-                  year    = update(x, ydays = 1, hours = 0, minutes = 0, seconds = 0))
+                  week     = update(x, wdays = 1, hours = 0, minutes = 0, seconds = 0),
+                  month    = update(x, mdays = 1, hours = 0, minutes = 0, seconds = 0),
+                  bimonth  = update(x, months = floor_multi_months(month(x), 2), mdays = 1, hours = 0, minutes = 0, seconds = 0),
+                  quarter  = update(x, months = floor_multi_months(month(x), 3), mdays = 1, hours = 0, minutes = 0, seconds = 0),
+                  halfyear = update(x, months = floor_multi_months(month(x), 6), mdays = 1, hours = 0, minutes = 0, seconds = 0),
+                  year     = update(x, ydays = 1, hours = 0, minutes = 0, seconds = 0))
     new
   }
 }
@@ -142,7 +156,7 @@ floor_date <- function(x, unit = c("second", "minute", "hour", "day", "week", "m
 #' ceiling_date(x, "month", change_on_boundary = TRUE)
 #' ## [1] "2000-02-01"
 ceiling_date <- function(x,
-                         unit = c("second", "minute", "hour", "day", "week", "month", "year", "quarter"),
+                         unit = c("second", "minute", "hour", "day", "week", "month", "bimonth", "quarter", "halfyear", "year"),
                          change_on_boundary = getOption("lubridate.ceiling_date.change_on_boundary", FALSE)) {
   if(!length(x))
     return(x)
@@ -176,32 +190,25 @@ ceiling_date <- function(x,
       else update(x, seconds = second(x) - 0.00001, simple = T)
 
     new <- switch(unit,
-                  minute  = update(new, minute = minute(new) + 1L, second = 0, simple = T),
-                  hour    = update(new, hour = hour(new) + 1L, minute = 0, second = 0, simple = T),
-                  day     = update(new, day = day(new) + 1L, hour = 0, minute = 0, second = 0),
-                  week    = update(new, wday = 8, hour = 0, minute = 0, second = 0),
-                  month   = update(new, month = month(new) + 1L, mday = 1, hour = 0, minute = 0, second = 0),
-                  quarter = update(new, month = ((month(new)-1)%/%3)*3+4, mday = 1, hour = 0, minute = 0, second = 0),
-                  year    = update(new, year = year(new) + 1L, month = 1, mday = 1,  hour = 0, minute = 0, second = 0))
+                  minute   = update(new, minute = minute(new) + 1L, second = 0, simple = T),
+                  hour     = update(new, hour = hour(new) + 1L, minute = 0, second = 0, simple = T),
+                  day      = update(new, day = day(new) + 1L, hour = 0, minute = 0, second = 0),
+                  week     = update(new, wday = 8, hour = 0, minute = 0, second = 0),
+                  month    = update(new, month = month(new) + 1L, mday = 1, hour = 0, minute = 0, second = 0),
+                  bimonth  = update(new, month = ceil_multi_months(month(new), 2), mday = 1, hour = 0, minute = 0, second = 0),
+                  quarter  = update(new, month = ceil_multi_months(month(new), 3), mday = 1, hour = 0, minute = 0, second = 0),
+                  halfyear = update(new, month = ceil_multi_months(month(new), 6), mday = 1, hour = 0, minute = 0, second = 0),
+                  year     = update(new, year = year(new) + 1L, month = 1, mday = 1,  hour = 0, minute = 0, second = 0))
     reclass_date(new, x)
 
   }
 }
 
-## fixme: this function is nowhere used
-parse_unit_spec <- function(unitspec) {
-  parts <- strsplit(unitspec, " ")[[1]]
-  if (length(parts) == 1) {
-    mult <- 1
-    unit <- unitspec
-  } else {
-    mult <- as.numeric(parts[[1]])
-    unit <- parts[[2]]
-  }
+# Utilities for calculating the floor/ceil month for units like bimonth, quarter, halfyear
+floor_multi_months <- function(month, len) {
+  (((month - 1) %/% len) * len) + 1
+}
 
-  unit <- gsub("s$", "", unit)
-  unit <- match.arg(unit,
-    c("second","minute","hour","day", "week", "month", "year"))
-
-  list(unit = unit, mult = mult)
+ceil_multi_months <- function(month, len) {
+  (((month - 1) %/% len) *  len) + (len + 1)
 }

--- a/man/round_date.Rd
+++ b/man/round_date.Rd
@@ -7,13 +7,13 @@
 \title{Round, floor and ceiling methods for date-time objects.}
 \usage{
 round_date(x, unit = c("second", "minute", "hour", "day", "week", "month",
-  "year", "quarter"))
+  "bimonth", "quarter", "halfyear", "year"))
 
 floor_date(x, unit = c("second", "minute", "hour", "day", "week", "month",
-  "year", "quarter"))
+  "bimonth", "quarter", "halfyear", "year"))
 
 ceiling_date(x, unit = c("second", "minute", "hour", "day", "week", "month",
-  "year", "quarter"),
+  "bimonth", "quarter", "halfyear", "year"),
   change_on_boundary = getOption("lubridate.ceiling_date.change_on_boundary",
   FALSE))
 }
@@ -21,7 +21,7 @@ ceiling_date(x, unit = c("second", "minute", "hour", "day", "week", "month",
 \item{x}{a vector of date-time objects}
 
 \item{unit}{a character string specifying the time unit to be rounded to. Should be one of
-"second", "minute", "hour", "day", "week", "month", "quarter", or "year."}
+"second", "minute", "hour", "day", "week", "month", "bimonth", "quarter", "halfyear", or "year."}
 
 \item{change_on_boundary}{logical. If FALSE (the default) \code{ceiling_date}
 don't alter date-times on the corresponding boundary. The boundary is unit
@@ -38,7 +38,7 @@ x with the appropriate units floored
 }
 \description{
 Users can specify whether to round to the nearest second, minute, hour, day,
-week, month, quarter, or year.
+week, month, bimonth, quarter, halfyear, or year.
 }
 \details{
 \code{round_date} takes a date-time object and rounds it to the nearest
@@ -72,7 +72,11 @@ round_date(x, "week")
 # "2009-08-02 CDT"
 round_date(x, "month")
 # "2009-08-01 CDT"
+round_date(x, "bimonth")
+# "2009-09-01 CDT"
 round_date(x, "quarter")
+# "2009-07-01 CDT"
+round_date(x, "halfyear")
 # "2009-07-01 CDT"
 round_date(x, "year")
 # "2010-01-01 CST"
@@ -90,7 +94,11 @@ floor_date(x, "week")
 # "2009-08-02 CDT"
 floor_date(x, "month")
 # "2009-08-01 CDT"
+floor_date(x, "bimonth")
+# "2009-07-01 CDT"
 floor_date(x, "quarter")
+# "2009-07-01 CDT"
+floor_date(x, "halfyear")
 # "2009-07-01 CDT"
 floor_date(x, "year")
 # "2009-01-01 CST"
@@ -108,8 +116,12 @@ ceiling_date(x, "week")
 # "2009-08-09 CDT"
 ceiling_date(x, "month")
 # "2009-09-01 CDT"
+ceiling_date(x, "bimonth")
+# "2009-09-01 CDT"
 ceiling_date(x, "quarter")
 # "2009-10-01 CDT"
+ceiling_date(x, "halfyear")
+# "2010-01-01 CDT"
 ceiling_date(x, "year")
 # "2010-01-01 CST"
 

--- a/tests/testthat/test-round.R
+++ b/tests/testthat/test-round.R
@@ -15,7 +15,11 @@ test_that("floor_date works for each time element",{
   	"2009-08-02 00:00:00", tz = "UTC"))
   expect_identical(floor_date(x, "month"), as.POSIXct(
   	"2009-08-01 00:00:00", tz = "UTC"))
+  expect_identical(floor_date(x, "bimonth"), as.POSIXct(
+  	"2009-07-01 00:00:00", tz = "UTC"))
   expect_identical(floor_date(x, "quarter"), as.POSIXct(
+    "2009-07-01 00:00:00", tz = "UTC"))
+  expect_identical(floor_date(x, "halfyear"), as.POSIXct(
     "2009-07-01 00:00:00", tz = "UTC"))
   expect_identical(floor_date(x, "year"), as.POSIXct(
   	"2009-01-01 00:00:00", tz = "UTC"))
@@ -36,8 +40,12 @@ test_that("ceiling_date works for each time element",{
   	"2009-08-09 00:00:00", tz = "UTC"))
   expect_identical(ceiling_date(x, "month"), as.POSIXct(
   	"2009-09-01 00:00:00", tz = "UTC"))
+  expect_identical(ceiling_date(x, "bimonth"), as.POSIXct(
+  	"2009-09-01 00:00:00", tz = "UTC"))
   expect_identical(ceiling_date(x, "quarter"), as.POSIXct(
     "2009-10-01 00:00:00", tz = "UTC"))
+  expect_identical(ceiling_date(x, "halfyear"), as.POSIXct(
+  	"2010-01-01 00:00:00", tz = "UTC"))
   expect_identical(ceiling_date(x, "year"), as.POSIXct(
   	"2010-01-01 00:00:00", tz = "UTC"))
 })
@@ -57,8 +65,12 @@ test_that("round_date works for each time element",{
   	"2009-08-02 00:00:00", tz = "UTC"))
   expect_identical(round_date(x, "month"), as.POSIXct(
   	"2009-08-01 00:00:00", tz = "UTC"))
+  expect_identical(round_date(x, "bimonth"), as.POSIXct(
+  	"2009-09-01 00:00:00", tz = "UTC"))
   expect_identical(round_date(x, "quarter"), as.POSIXct(
     "2009-07-01 00:00:00", tz = "UTC"))
+  expect_identical(round_date(x, "halfyear"), as.POSIXct(
+  	"2009-07-01 00:00:00", tz = "UTC"))
   expect_identical(round_date(x, "year"), as.POSIXct(
   	"2010-01-01 00:00:00", tz = "UTC"))
 })
@@ -133,6 +145,12 @@ test_that("floor_date works for a variety of formats",{
     as.POSIXct("2009-08-03 12:01:00", tz = "UTC"))
   expect_identical(floor_date(as.Date(x), "month"),
     as.Date("2009-08-01"))
+  expect_identical(floor_date(as.Date(x), "bimonth"),
+    ymd("2009-07-01"))
+  expect_identical(floor_date(as.Date(x), "quarter"),
+    ymd("2009-07-01"))
+  expect_identical(floor_date(as.Date(x), "halfyear"),
+    ymd("2009-07-01"))
   expect_identical(floor_date(as.POSIXlt(x), "minute"),
     as.POSIXlt(as.POSIXct("2009-08-03 12:01:00", tz = "UTC")))
 })
@@ -144,6 +162,12 @@ test_that("ceiling_date works for a variety of formats",{
     as.POSIXct("2009-08-03 12:02:00", tz = "UTC"))
   expect_identical(ceiling_date(as.Date(x), "month"),
     as.Date("2009-09-01"))
+  expect_identical(ceiling_date(as.Date(x), "bimonth"),
+    ymd("2009-09-01"))
+  expect_identical(ceiling_date(as.Date(x), "quarter"),
+    ymd("2009-10-01"))
+  expect_identical(ceiling_date(as.Date(x), "halfyear"),
+    ymd("2010-01-01"))
   expect_identical(ceiling_date(as.POSIXlt(x), "minute"),
     as.POSIXlt(as.POSIXct("2009-08-03 12:02:00", tz =
     "UTC")))
@@ -178,12 +202,14 @@ test_that("ceiling_date does not round up dates that are already on a boundary",
   expect_equal(ceiling_date(ymd_hms("2012-09-01 00:00:00"), 'month'), as.POSIXct("2012-09-01", tz = "UTC"))
   expect_equal(ceiling_date(ymd_hms("2012-01-01 00:00:00"), 'year'), as.POSIXct("2012-01-01", tz = "UTC"))
   expect_equal(ceiling_date(ymd_hms("2012-01-01 01:00:00"), 'second'), ymd_hms("2012-01-01 01:00:00"))
+  expect_equal(ceiling_date(ymd_hms("2012-01-01 00:00:00"), 'bimonth'), ymd_hms("2012-01-01 00:00:00"))
 })
 
 test_that("ceiling_date does round up dates on a boundary with change_on_boundary=TRUE",{
   expect_equal(ceiling_date(as.Date("2012-09-27"), 'day', TRUE), as.Date("2012-09-28"))
   expect_equal(ceiling_date(as.Date("2012-09-01"), 'month', TRUE), as.Date("2012-10-01"))
   expect_equal(ceiling_date(ymd_hms("2012-09-01 00:00:00"), 'month', TRUE), ymd("2012-10-01", tz = "UTC"))
+  expect_equal(ceiling_date(ymd_hms("2012-09-01 00:00:00"), 'bimonth', TRUE), ymd("2012-11-01", tz = "UTC"))
   expect_equal(ceiling_date(ymd_hms("2012-01-01 00:00:00"), 'year', TRUE), as.POSIXct("2013-01-01", tz = "UTC"))
   expect_equal(ceiling_date(ymd_hms("2012-01-01 01:00:00"), 'hour', TRUE), ymd_hms("2012-01-01 02:00:00"))
   expect_equal(ceiling_date(ymd_hms("2012-01-01 00:00:00"), 'day', TRUE), ymd("2012-01-02", tz = "UTC"))


### PR DESCRIPTION
For #268. Did a little refactoring to re-use the formula used in rounding to "quarter".

Also, deleted that `parse_unit_spec` function since it really was dead code, and changed an errant tab to spaces.

Still need to write specs.