### PR TITLE
Add shift parameter to quarters function when fiscal does not match calendar year

### DIFF
--- a/R/accessors-quarter.r
+++ b/R/accessors-quarter.r
@@ -1,17 +1,22 @@
 #' @include accessors-month.r
 NULL
 
-#' Get the fiscal quarter of a date-time.
+#' Get the calendar or fiscal quarter of a date-time.
 #'
-#' Fiscal quarters are a way of dividing the year into fourths. The first quarter (Q1)
+#' Calendar quarters are a way of dividing the year into fourths. The first quarter (Q1)
 #' comprises January, February and March; the second quarter (Q2) comprises April, May,
 #' June; the third quarter (Q3) comprises July, August, September; the fourth quarter (Q4)
-#' October, November, December.
+#' October, November, December. Fiscal quarters often do not align with calendar quarters,
+#' but are shifted such that the beginning of the fiscal year is a set number of months prior or
+#' subsequent to January.
 #'
 #' @param x a date-time object of class POSIXct, POSIXlt, Date, chron, yearmon, yearqtr, zoo,
 #' zooreg, timeDate, xts, its, ti, jul, timeSeries, fts or anything else that can be converted
 #' with as.POSIXlt
 #' @param with_year logical indicating whether or not to include the quarter's year.
+#' @param shift numeric indicating the relative position of the fiscal year
+#' from the first month of the year. For example, a fiscal year that starts in November is shifted
+#' -2 from January.
 #' @keywords utilities manip chron methods
 #' @return numeric the fiscal quarter that the date-time occurs in
 #' @examples
@@ -20,8 +25,10 @@ NULL
 #' # 1 2 3 4
 #' quarter(x, with_year = TRUE)
 #' # 2012.1 2012.2 2012.3 2012.4
+#' quarter(x, with_year = TRUE, shift = -2)
+#' # 2012.2 2012.3 2012.4 2013.1
 #' @export
-quarter <- function(x, with_year = FALSE) {
+quarter <- function(x, with_year = FALSE, shift = 0) {
   m <- month(x)
   quarters <- c("1" = 1,
                 "2" = 1,
@@ -35,9 +42,13 @@ quarter <- function(x, with_year = FALSE) {
                 "10" = 4,
                 "11" = 4,
                 "12" = 4)
+  shifted <- (seq(0,11) + shift) %% 12 + 1
+  m_shifted <- match(m, shifted)
   if (isTRUE(with_year)){
-    q <- unname(quarters[m])
-    y <- year(x)
+    q <- unname(quarters[m_shifted])
+    unshifted_q <- unname(quarters[m])
+    inc_year <- q == 1 & unshifted_q == 4
+    y <- year(x) + inc_year
     as.numeric(paste0(y, ".", q))
-  } else unname(quarters[m])
+  } else unname(quarters[m_shifted])
 }

--- a/R/accessors-quarter.r
+++ b/R/accessors-quarter.r
@@ -14,9 +14,7 @@ NULL
 #' zooreg, timeDate, xts, its, ti, jul, timeSeries, fts or anything else that can be converted
 #' with as.POSIXlt
 #' @param with_year logical indicating whether or not to include the quarter's year.
-#' @param shift numeric indicating the relative position of the fiscal year
-#' from the first month of the year. For example, a fiscal year that starts in November is shifted
-#' -2 from January.
+#' @param fiscal_start numeric indicating the month in which the fiscal year starts, e.g. 11 for November
 #' @keywords utilities manip chron methods
 #' @return numeric the fiscal quarter that the date-time occurs in
 #' @examples
@@ -25,10 +23,10 @@ NULL
 #' # 1 2 3 4
 #' quarter(x, with_year = TRUE)
 #' # 2012.1 2012.2 2012.3 2012.4
-#' quarter(x, with_year = TRUE, shift = -2)
+#' quarter(x, with_year = TRUE, fiscal_start = 11)
 #' # 2012.2 2012.3 2012.4 2013.1
 #' @export
-quarter <- function(x, with_year = FALSE, shift = 0) {
+quarter <- function(x, with_year = FALSE, fiscal_start = 1) {
   m <- month(x)
   quarters <- c("1" = 1,
                 "2" = 1,
@@ -42,7 +40,7 @@ quarter <- function(x, with_year = FALSE, shift = 0) {
                 "10" = 4,
                 "11" = 4,
                 "12" = 4)
-  shifted <- (seq(0,11) + shift) %% 12 + 1
+  shifted <- seq(fiscal_start - 1, 10 + fiscal_start) %% 12 + 1
   m_shifted <- match(m, shifted)
   if (isTRUE(with_year)){
     q <- unname(quarters[m_shifted])

--- a/man/quarter.Rd
+++ b/man/quarter.Rd
@@ -2,9 +2,9 @@
 % Please edit documentation in R/accessors-quarter.r
 \name{quarter}
 \alias{quarter}
-\title{Get the fiscal quarter of a date-time.}
+\title{Get the calendar or fiscal quarter of a date-time.}
 \usage{
-quarter(x, with_year = FALSE)
+quarter(x, with_year = FALSE, shift = 0)
 }
 \arguments{
 \item{x}{a date-time object of class POSIXct, POSIXlt, Date, chron, yearmon, yearqtr, zoo,
@@ -12,15 +12,21 @@ zooreg, timeDate, xts, its, ti, jul, timeSeries, fts or anything else that can b
 with as.POSIXlt}
 
 \item{with_year}{logical indicating whether or not to include the quarter's year.}
+
+\item{shift}{numeric indicating the relative position of the fiscal year
+from the first month of the year. For example, a fiscal year that starts in November is shifted
+-2 from January.}
 }
 \value{
 numeric the fiscal quarter that the date-time occurs in
 }
 \description{
-Fiscal quarters are a way of dividing the year into fourths. The first quarter (Q1)
+Calendar quarters are a way of dividing the year into fourths. The first quarter (Q1)
 comprises January, February and March; the second quarter (Q2) comprises April, May,
 June; the third quarter (Q3) comprises July, August, September; the fourth quarter (Q4)
-October, November, December.
+October, November, December. Fiscal quarters often do not align with calendar quarters,
+but are shifted such that the beginning of the fiscal year is a set number of months prior or
+subsequent to January.
 }
 \examples{
 x <- ymd(c("2012-03-26", "2012-05-04", "2012-09-23", "2012-12-31"))
@@ -28,6 +34,8 @@ quarter(x)
 # 1 2 3 4
 quarter(x, with_year = TRUE)
 # 2012.1 2012.2 2012.3 2012.4
+quarter(x, with_year = TRUE, shift = -2)
+# 2012.2 2012.3 2012.4 2013.1
 }
 \keyword{chron}
 \keyword{manip}

--- a/man/quarter.Rd
+++ b/man/quarter.Rd
@@ -4,7 +4,7 @@
 \alias{quarter}
 \title{Get the calendar or fiscal quarter of a date-time.}
 \usage{
-quarter(x, with_year = FALSE, shift = 0)
+quarter(x, with_year = FALSE, fiscal_start = 1)
 }
 \arguments{
 \item{x}{a date-time object of class POSIXct, POSIXlt, Date, chron, yearmon, yearqtr, zoo,
@@ -13,9 +13,7 @@ with as.POSIXlt}
 
 \item{with_year}{logical indicating whether or not to include the quarter's year.}
 
-\item{shift}{numeric indicating the relative position of the fiscal year
-from the first month of the year. For example, a fiscal year that starts in November is shifted
--2 from January.}
+\item{fiscal_start}{numeric indicating the month in which the fiscal year starts, e.g. 11 for November}
 }
 \value{
 numeric the fiscal quarter that the date-time occurs in
@@ -34,7 +32,7 @@ quarter(x)
 # 1 2 3 4
 quarter(x, with_year = TRUE)
 # 2012.1 2012.2 2012.3 2012.4
-quarter(x, with_year = TRUE, shift = -2)
+quarter(x, with_year = TRUE, fiscal_start = 11)
 # 2012.2 2012.3 2012.4 2013.1
 }
 \keyword{chron}

--- a/tests/testthat/test-accessors.R
+++ b/tests/testthat/test-accessors.R
@@ -83,18 +83,18 @@ test_that("quarters accessor extracts correct quarter", {
 
   expect_that(quarter(poslt), equals(4))
   expect_that(quarter(poslt, with_year = TRUE), equals(2010.4))
-  expect_that(quarter(poslt, shift = -2), equals(1))
-  expect_that(quarter(poslt, with_year = TRUE, shift = -2 ), equals(2011.1))
+  expect_that(quarter(poslt, fiscal_start = 11), equals(1))
+  expect_that(quarter(poslt, with_year = TRUE, fiscal_start = -2 ), equals(2011.1))
 
   expect_that(quarter(posct), equals(4))
   expect_that(quarter(posct, with_year = TRUE), equals(2010.4))
-  expect_that(quarter(posct, shift = -2), equals(1))
-  expect_that(quarter(posct, with_year = TRUE, shift = -2 ), equals(2011.1))
+  expect_that(quarter(posct, fiscal_start = 11), equals(1))
+  expect_that(quarter(posct, with_year = TRUE, fiscal_start = -2 ), equals(2011.1))
 
   expect_that(quarter(date), equals(4))
   expect_that(quarter(date, with_year = TRUE), equals(2010.4))
-  expect_that(quarter(date, shift = -2), equals(1))
-  expect_that(quarter(date, with_year = TRUE, shift = -2 ), equals(2011.1))
+  expect_that(quarter(date, fiscal_start = 11), equals(1))
+  expect_that(quarter(date, with_year = TRUE, fiscal_start = -2 ), equals(2011.1))
 })
 
 test_that("isoweek accessor extracts correct ISO8601 week",{

--- a/tests/testthat/test-accessors.R
+++ b/tests/testthat/test-accessors.R
@@ -75,6 +75,28 @@ test_that("weeks accessor extracts correct week",{
 
 })
 
+test_that("quarters accessor extracts correct quarter", {
+  poslt <- as.POSIXlt("2010-11-03 13:45:59", tz = "UTC", format
+                      = "%Y-%m-%d %H:%M:%S")
+  posct <- as.POSIXct(poslt)
+  date <- as.Date(poslt)
+
+  expect_that(quarter(poslt), equals(4))
+  expect_that(quarter(poslt, with_year = TRUE), equals(2010.4))
+  expect_that(quarter(poslt, shift = -2), equals(1))
+  expect_that(quarter(poslt, with_year = TRUE, shift = -2 ), equals(2011.1))
+
+  expect_that(quarter(posct), equals(4))
+  expect_that(quarter(posct, with_year = TRUE), equals(2010.4))
+  expect_that(quarter(posct, shift = -2), equals(1))
+  expect_that(quarter(posct, with_year = TRUE, shift = -2 ), equals(2011.1))
+
+  expect_that(quarter(date), equals(4))
+  expect_that(quarter(date, with_year = TRUE), equals(2010.4))
+  expect_that(quarter(date, shift = -2), equals(1))
+  expect_that(quarter(date, with_year = TRUE, shift = -2 ), equals(2011.1))
+})
+
 test_that("isoweek accessor extracts correct ISO8601 week",{
   poslt <- as.POSIXlt("2010-01-01 13:45:59", tz = "UTC", format = "%Y-%m-%d %H:%M:%S")
   posct <- as.POSIXct(poslt)


### PR DESCRIPTION
A calendar year starts in January, but many places have fiscal years that start either before or after the calendar year. For example, a fiscal year might start in November, which means Q1 is Nov - Jan and Q4 is Aug - Oct.

The shift parameter causes two major changes, one is that the shift changes the quarter for a particular month, as described above. 2nd change is that it also increases the year by 1 if the quarter would 'normally' be Q4 but is now Q1 due to a shift. E.g. December 2015 is normally 2015.Q4 but would be reported as 2016.Q1 if the Fiscal Year started in December. 

Created new test cases as well, as I could not find any for the quarter accessor. 