### PR TITLE
Fix format.Duration for durations greater than a minute with fractional seconds

### DIFF
--- a/R/durations.r
+++ b/R/durations.r
@@ -70,7 +70,7 @@ SECONDS_IN_ONE <- c(
     paste0(x, "s")
   else {
     x2 <- round(x / SECONDS_IN_ONE[[unit]], 2)
-    sprintf("%ss (~%s %ss)", x, x2, unit)
+    sprintf("%ds (~%s %ss)", round(x), x2, unit)
   }
 }
 

--- a/R/durations.r
+++ b/R/durations.r
@@ -70,7 +70,7 @@ SECONDS_IN_ONE <- c(
     paste0(x, "s")
   else {
     x2 <- round(x / SECONDS_IN_ONE[[unit]], 2)
-    sprintf("%ds (~%s %ss)", round(x), x2, unit)
+    sprintf("%ss (~%s %ss)", x, x2, unit)
   }
 }
 

--- a/R/durations.r
+++ b/R/durations.r
@@ -70,7 +70,7 @@ SECONDS_IN_ONE <- c(
     paste0(x, "s")
   else {
     x2 <- round(x / SECONDS_IN_ONE[[unit]], 2)
-    sprintf("%ds (~%s %ss)", x, x2, unit, "s)")
+    sprintf("%ss (~%s %ss)", x, x2, unit)
   }
 }
 

--- a/tests/testthat/test-durations.R
+++ b/tests/testthat/test-durations.R
@@ -163,11 +163,11 @@ test_that("summary.Duration creates useful summary", {
 
 test_that("format.Duration works with NA values", {
   expect_equal(format(duration(c(NA, 1, 100, 10000, 100000, 100000000, 75.25, 75.5001))),
-               c(NA, "1s", "100s (~1.67 minutes)", "10000s (~2.78 hours)", "100000s (~1.16 days)",
-                 "100000000s (~3.17 years)",
-                 "75s (~1.25 minutes)", "76s (~1.26 minutes)"))
+               c(NA, "1s", "100s (~1.67 minutes)", "10000s (~2.78 hours)", "1e+05s (~1.16 days)",
+                 "1e+08s (~3.17 years)",
+                 "75.25s (~1.25 minutes)", "75.5001s (~1.26 minutes)"))
   expect_equal(format(duration(c(75.25, 75.5001))),
-               c("75s (~1.25 minutes)", "76s (~1.26 minutes)"))
+               c("75.25s (~1.25 minutes)", "75.5001s (~1.26 minutes)"))
 })
 
 test_that("as.duration handles NA interval objects", {

--- a/tests/testthat/test-durations.R
+++ b/tests/testthat/test-durations.R
@@ -153,6 +153,7 @@ test_that("format.Duration correctly displays durations with an NA", {
   expect_equivalent(format(dur), c("5s", NA))
 })
 
+
 test_that("summary.Duration creates useful summary", {
   dur <- dminutes(5)
   text <- c(rep("300s (~5 minutes)", 6), 1)
@@ -161,9 +162,10 @@ test_that("summary.Duration creates useful summary", {
 })
 
 test_that("format.Duration works with NA values", {
-  expect_equal(format(duration(c(NA, 1, 100, 10000, 100000, 100000000))),
+  expect_equal(format(duration(c(NA, 1, 100, 10000, 100000, 100000000, 75.25, 75.5001))),
                c(NA, "1s", "100s (~1.67 minutes)", "10000s (~2.78 hours)", "100000s (~1.16 days)",
-                 "100000000s (~3.17 years)"))
+                 "100000000s (~3.17 years)",
+                 "75s (~1.25 minutes)", "76s (~1.26 minutes)"))
 })
 
 test_that("as.duration handles NA interval objects", {

--- a/tests/testthat/test-durations.R
+++ b/tests/testthat/test-durations.R
@@ -166,6 +166,8 @@ test_that("format.Duration works with NA values", {
                c(NA, "1s", "100s (~1.67 minutes)", "10000s (~2.78 hours)", "100000s (~1.16 days)",
                  "100000000s (~3.17 years)",
                  "75s (~1.25 minutes)", "76s (~1.26 minutes)"))
+  expect_equal(format(duration(c(75.25, 75.5001))),
+               c("75s (~1.25 minutes)", "76s (~1.26 minutes)"))
 })
 
 test_that("as.duration handles NA interval objects", {


### PR DESCRIPTION

Previously format(duration(75.25)), for example, would fail because .read_duration used %d as the format specifier in sprintf. In order to match the existing format.Duration tests, I simply round the seconds.

Added tests to test-durations.R