### PR TITLE
add fiscal_start to quarter when fiscal year doesn't begin in january

### DIFF
--- a/R/accessors-quarter.r
+++ b/R/accessors-quarter.r
@@ -10,19 +10,28 @@ NULL
 #'   anything else that can be converted with as.POSIXlt
 #' @param with_year logical indicating whether or not to include the quarter's
 #'   year.
+#' @param fiscal_start numeric indicating the starting month of a fiscal year
 #' @return numeric
 #' @examples
 #' x <- ymd(c("2012-03-26", "2012-05-04", "2012-09-23", "2012-12-31"))
 #' quarter(x)
 #' quarter(x, with_year = TRUE)
+#' quarter(x, with_year = TRUE, fiscal_start = 11)
 #' semester(x)
 #' semester(x, with_year = TRUE)
 #' @export
-quarter <- function(x, with_year = FALSE) {
+quarter <- function(x, with_year = FALSE, fiscal_start = 1) {
+  fs <- fiscal_start - 1
+  shifted <- seq(fs, 11 + fs) %% 12 + 1
   m <- month(x)
   quarters <- rep(1:4, each = 3)
-  q <- quarters[m]
-  if (with_year) year(x) + q/10
+  s <- match(m, shifted)
+  q <- quarters[s]
+  if (with_year) {
+    uq <- quarters[m]
+    inc_year <- q == 1 & uq == 4
+    year(x) + inc_year + q/10
+  }
   else q
 }
 

--- a/man/quarter.Rd
+++ b/man/quarter.Rd
@@ -5,7 +5,7 @@
 \alias{semester}
 \title{Get the fiscal quarter and semester of a date-time.}
 \usage{
-quarter(x, with_year = FALSE)
+quarter(x, with_year = FALSE, fiscal_start = 1)
 
 semester(x, with_year = FALSE)
 }
@@ -16,6 +16,8 @@ anything else that can be converted with as.POSIXlt}
 
 \item{with_year}{logical indicating whether or not to include the quarter's
 year.}
+
+\item{fiscal_start}{numeric indicating the starting month of a fiscal year}
 }
 \value{
 numeric
@@ -27,6 +29,7 @@ Quarters divide the year into fourths. Semesters divide the year into halfs.
 x <- ymd(c("2012-03-26", "2012-05-04", "2012-09-23", "2012-12-31"))
 quarter(x)
 quarter(x, with_year = TRUE)
+quarter(x, with_year = TRUE, fiscal_start = 11)
 semester(x)
 semester(x, with_year = TRUE)
 }

--- a/tests/testthat/test-accessors.R
+++ b/tests/testthat/test-accessors.R
@@ -104,6 +104,28 @@ test_that("months accessor extracts correct month",{
 
 })
 
+test_that("quarters accessor extracts correct quarter", {
+  poslt <- as.POSIXlt("2010-11-03 13:45:59", tz = "UTC", format
+                      = "%Y-%m-%d %H:%M:%S")
+  posct <- as.POSIXct(poslt)
+  date <- as.Date(poslt)
+
+  expect_that(quarter(poslt), equals(4))
+  expect_that(quarter(poslt, with_year = TRUE), equals(2010.4))
+  expect_that(quarter(poslt, fiscal_start = 11), equals(1))
+  expect_that(quarter(poslt, with_year = TRUE, fiscal_start = -2 ), equals(2011.1))
+
+  expect_that(quarter(posct), equals(4))
+  expect_that(quarter(posct, with_year = TRUE), equals(2010.4))
+  expect_that(quarter(posct, fiscal_start = 11), equals(1))
+  expect_that(quarter(posct, with_year = TRUE, fiscal_start = -2 ), equals(2011.1))
+
+  expect_that(quarter(date), equals(4))
+  expect_that(quarter(date, with_year = TRUE), equals(2010.4))
+  expect_that(quarter(date, fiscal_start = 11), equals(1))
+  expect_that(quarter(date, with_year = TRUE, fiscal_start = -2 ), equals(2011.1))
+})
+
 test_that("years accessor extracts correct year",{
   poslt <- as.POSIXlt("2010-02-03 13:45:59", tz = "UTC", format
      = "%Y-%m-%d %H:%M:%S")


### PR DESCRIPTION
This is a follow-up to Pull Request #427 , but I couldn't figure out how to use git properly to bring my old fork up so I deleted and started again. 

I removed shift as requested, and created a fiscal_start parameter instead. Specifying a month other than 1 for the start of the fiscal year will shift the quarter (and the year if needed). For example, setting 11 for start will mean that Nov, Dec, Jan are all Q1. For Nov and Dec, the year will increment by 1 if with_year = TRUE. That is, 2013-11 will show as 2014.1 (1st quarter of 2014, as is convention when using fiscal quarters). 

I have also added tests for quarters which did not exist previously.