### PR TITLE
ceiling_date handles missing value propely

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,8 @@ Version 1.6.0.9000
 * [#466](https://github.com/hadley/lubridate/pull/466) Fix wrong formats within ymd_h family of functions.
 * [#472](https://github.com/hadley/lubridate/pull/472) Printing method for duration doesn't throw format error on fractional seconds.
 * [#475](https://github.com/hadley/lubridate/pull/475) character<> comparisons is no longer slow.
+* [#486](https://github.com/hadley/lubridate/issues/486) ceiling_date handles `NA` properly.
+
 
 Version 1.6.0
 =============

--- a/R/round.r
+++ b/R/round.r
@@ -232,7 +232,7 @@ ceiling_date <- function(x, unit = "seconds", change_on_boundary = NULL) {
         trunc_multi_unit(new, unit, n) + delta
       } else{
         new1 <- trunc_multi_unit(new, unit, n)
-        not_same <- new1 != new
+        not_same <- which(new1 != new)
         new1[not_same] <- new1[not_same] + delta
         new1
       }

--- a/tests/testthat/test-round.R
+++ b/tests/testthat/test-round.R
@@ -386,13 +386,21 @@ test_that("round_date and ceiling_date skip day time gap", {
   expect_equal(round_date(x, "hour"),  y)
 })
 
-test_that("ceiling_date behaves correctly with NA", {
+test_that("ceiling_date, round_date and floor_date behave correctly with NA", {
   ## (bug #486)
-  x <- ymd_hms("2009-08-03 12:01:59", tz = "UTC") + (0:1)*days()
+  x <- ymd_hms("2009-08-03 12:01:59.23", tz = "UTC") + (0:1)*days()
   x[2] <- NA
-  y <- ymd("2009-08-04", tz = "UTC") + (0:1)*days()
-  y[2] <- NA
   expect_equal(ceiling_date(x, unit = "day"),
-               y)
+               c(ymd("2009-08-04", tz = "UTC"), NA))
+  expect_equal(ceiling_date(x, unit = "seconds"),
+               c(ymd_hms("2009-08-03 12:02:00", tz = "UTC"), NA))
+  expect_equal(ceiling_date(x, unit = "months"),
+               c(ymd("2009-09-01", tz = "UTC"), NA))
+  expect_equal(floor_date(x, unit = "day"),
+               c(ymd("2009-08-03", tz = "UTC"), NA))
+  expect_equal(floor_date(x, unit = "months"),
+               c(ymd("2009-08-01", tz = "UTC"), NA))
+  expect_equal(round_date(x, unit = "minute"),
+               c(ymd_hms("2009-08-03 12:02:00", tz = "UTC"), NA))
 })
 

--- a/tests/testthat/test-round.R
+++ b/tests/testthat/test-round.R
@@ -385,3 +385,14 @@ test_that("round_date and ceiling_date skip day time gap", {
 
   expect_equal(round_date(x, "hour"),  y)
 })
+
+test_that("ceiling_date behaves correctly with NA", {
+  ## (bug #486)
+  x <- ymd_hms("2009-08-03 12:01:59", tz = "UTC") + (0:1)*days()
+  x[2] <- NA
+  y <- ymd("2009-08-04", tz = "UTC") + (0:1)*days()
+  y[2] <- NA
+  expect_equal(ceiling_date(x, unit = "day"),
+               y)
+})
+


### PR DESCRIPTION
Proposition to fix #486 . 
I added some tests and News bullet point

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hadley/lubridate/488)
<!-- Reviewable:end -->
