### PR TITLE
[Fix #490] Correctly compute length of period in months

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -16,6 +16,7 @@ Version 1.6.0.9000
 * [#475](https://github.com/hadley/lubridate/pull/475) character<> comparisons is no longer slow.
 * [#486](https://github.com/hadley/lubridate/issues/486) ceiling_date handles `NA` properly.
 * [#483](https://github.com/hadley/lubridate/pull/483) Fix add_duration_to_date error when duration first element is NA.
+* [#524](https://github.com/hadley/lubridate/pull/524) Correctly compute length of period in months (issue #490)
 
 Version 1.6.0
 =============

--- a/R/coercion.r
+++ b/R/coercion.r
@@ -547,7 +547,7 @@ seconds_to_unit <- function(secs, unit = "second"){
          minute = secs / 60,
          hour   = secs / 3600,
          day    = secs / 86400,
-         month  = secs / (86400 * 365.25)/12,
+         month  = secs / (86400 * 365.25 / 12),
          week   = secs / (86400 * 7),
          year   = secs / (86400 * 365.25),
          stop("invalid unit ", unit))


### PR DESCRIPTION
See discussion of this bug here:
http://stackoverflow.com/questions/42563471/unexpected-value-in-lubridate-as-numeric-using-value-months-in-units-arg/