### PR TITLE
[Fix #517] `day<-`, `minute<-`, etc. should not produce an error when…

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -17,6 +17,7 @@ Version 1.6.0.9000
 * [#486](https://github.com/hadley/lubridate/issues/486) ceiling_date handles `NA` properly.
 * [#483](https://github.com/hadley/lubridate/pull/483) Fix add_duration_to_date error when duration first element is NA.
 * [#524](https://github.com/hadley/lubridate/pull/524) Correctly compute length of period in months (issue #490)
+* [#525](https://github.com/hadley/lubridate/pull/525) Fix to prevent `day<-`, `minute<-`, etc. from producing an error when length(x) is 0 (issue #517)
 
 Version 1.6.0
 =============

--- a/R/periods.r
+++ b/R/periods.r
@@ -401,6 +401,8 @@ parse_period <- function(x){
     month = 0, year = 0
   )
 
+  if (nrow(pieces) == 0) defaults <- defaults[0, ]
+
   pieces <- cbind(pieces, defaults[setdiff(names(defaults), names(pieces))])
   ## pieces <- pieces[c("year", "month", "week", "day", "hour", "minute", "second")]
 


### PR DESCRIPTION
… length(x) is zero