### PR TITLE
Very, very minor typo correction

### DIFF
--- a/man/ymd.Rd
+++ b/man/ymd.Rd
@@ -34,7 +34,7 @@ yq(..., quiet = FALSE, tz = NULL, locale = Sys.getlocale("LC_TIME"))
 \arguments{
 \item{...}{a character or numeric vector of suspected dates}
 
-\item{quiet}{logical. When TRUE function evalueates without displaying
+\item{quiet}{logical. When TRUE function evaluates without displaying
 customary messages.}
 
 \item{tz}{Time zone indicator. If NULL (default) a Date object is


### PR DESCRIPTION
Just noticed this in the documentation - `evalueates` should read `evaluates`.

Hope this is helpful.